### PR TITLE
Update to Elasticsearch v5.x

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>search_api_elasticsearch</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/includes/SearchApiElasticsearchAbstractService.inc
+++ b/includes/SearchApiElasticsearchAbstractService.inc
@@ -454,7 +454,7 @@ abstract class SearchApiElasticsearchAbstractService extends SearchApiAbstractSe
     switch ($type) {
       case 'text':
         return array(
-          'type' => 'string',
+          'type' => 'text',
           'boost' => $field['boost'],
         );
 
@@ -462,7 +462,7 @@ abstract class SearchApiElasticsearchAbstractService extends SearchApiAbstractSe
       case 'string':
       case 'token':
         return array(
-          'type' => 'string',
+          'type' => 'keyword',
           'index' => 'not_analyzed',
         );
 
@@ -944,7 +944,7 @@ abstract class SearchApiElasticsearchAbstractService extends SearchApiAbstractSe
   protected function getIndexName(SearchApiIndex $index) {
     global $databases;
 
-    $site_database = $databases['default']['default']['database'];
+    $site_database = strtolower($databases['default']['default']['database']);
 
     $index_machine_name = is_string($index) ? $index : $index->machine_name;
 
@@ -964,7 +964,7 @@ abstract class SearchApiElasticsearchAbstractService extends SearchApiAbstractSe
    */
   public function fieldsUpdated(SearchApiIndex $index) {
     $this->fieldsUpdatedProperties = array(
-      'id' => array('type' => 'string', 'include_in_all' => FALSE),
+      'id' => array('type' => 'keyword', 'include_in_all' => FALSE),
     );
     foreach ($index->getFields() as $field_id => $field_data) {
       $this->fieldsUpdatedProperties[$field_id] = $this->getFieldMapping($field_data);

--- a/includes/SearchApiElasticsearchAbstractService.inc
+++ b/includes/SearchApiElasticsearchAbstractService.inc
@@ -485,7 +485,7 @@ abstract class SearchApiElasticsearchAbstractService extends SearchApiAbstractSe
       case 'date':
         return array(
           'type' => 'date',
-          'format' => 'date_time',
+          'format' => 'date_time||epoch_millis||date_time_no_millis||date',
         );
 
       case 'location':

--- a/modules/elastica/composer.json
+++ b/modules/elastica/composer.json
@@ -11,6 +11,6 @@
     }
   ],
   "require": {
-    "ruflin/elastica": ">=v1.3.4.0"
+    "ruflin/elastica": ">=v5.1.0"
   }
 }

--- a/modules/elastica/includes/SearchApiElasticsearchElastica.inc
+++ b/modules/elastica/includes/SearchApiElasticsearchElastica.inc
@@ -197,6 +197,11 @@ class SearchApiElasticsearchElastica extends SearchApiElasticsearchAbstractServi
     $elastica_index = $this->getElasticaIndex($index);
     if (!empty($elastica_index)) {
       $elastica_type = $elastica_index->getType($index->machine_name);
+      $elastica_index_mapping = $elastica_index->getMapping();
+      $current_fields = array();
+      if(isset($elastica_index_mapping[$index->machine_name])) {
+        $current_fields = $elastica_index_mapping[$index->machine_name]['properties'];
+      }
 
       // Create a new mapping.
       $mapping = new Elastica\Type\Mapping();
@@ -207,8 +212,14 @@ class SearchApiElasticsearchElastica extends SearchApiElasticsearchAbstractServi
         foreach ($this->fieldsUpdatedProperties as $key => $value) {
           $fields[$key] = $value;
         }
-        $mapping->setProperties($fields);
-        $mapping->send();
+        //Get the new fields if this is an existing mapping.
+        if(!empty($current_fields) && count($current_fields) > 0) {
+          $fields = array_diff_key($fields,$current_fields);
+        }
+        if(count($fields) > 0) {
+          $mapping->setProperties($fields);
+          $mapping->send();
+        }
       }
       catch (Exception $e) {
         watchdog('Elasticsearch', check_plain($e->getMessage()), array(), WATCHDOG_ERROR);

--- a/modules/elastica/includes/SearchApiElasticsearchElastica.inc
+++ b/modules/elastica/includes/SearchApiElasticsearchElastica.inc
@@ -204,12 +204,6 @@ class SearchApiElasticsearchElastica extends SearchApiElasticsearchAbstractServi
       $mapping->setParam('_all', array('enabled' => FALSE));
       try {
         $fields = array();
-        foreach ($this->fieldsUpdatedProperties as $key => $value) {
-          if ($value['type']=='string') {
-            $value['type'] = 'keyword';
-          }
-          $fields[$key] = $value;
-        }
         $mapping->setProperties($fields);
         $mapping->send();
       }

--- a/modules/elastica/includes/SearchApiElasticsearchElastica.inc
+++ b/modules/elastica/includes/SearchApiElasticsearchElastica.inc
@@ -204,6 +204,9 @@ class SearchApiElasticsearchElastica extends SearchApiElasticsearchAbstractServi
       $mapping->setParam('_all', array('enabled' => FALSE));
       try {
         $fields = array();
+        foreach ($this->fieldsUpdatedProperties as $key => $value) {
+          $fields[$key] = $value;
+        }
         $mapping->setProperties($fields);
         $mapping->send();
       }

--- a/modules/elastica/includes/SearchApiElasticsearchElastica.inc
+++ b/modules/elastica/includes/SearchApiElasticsearchElastica.inc
@@ -172,7 +172,11 @@ class SearchApiElasticsearchElastica extends SearchApiElasticsearchAbstractServi
     if (!empty($elastica_index)) {
       try {
         drupal_alter('search_api_elasticsearch_elastica_add_index', $index->options);
-        $response = $elastica_index->create($index->options, TRUE);
+        $options = [
+          'number_of_shards' => $index->options['number_of_shards'],
+          'number_of_replicas' => $index->options['number_of_replicas']
+        ];
+        $response = $elastica_index->create($options, TRUE);
       }
       catch (Exception $e) {
         watchdog('Elasticsearch', check_plain($e->getMessage()), array(), WATCHDOG_ERROR);
@@ -199,18 +203,15 @@ class SearchApiElasticsearchElastica extends SearchApiElasticsearchAbstractServi
       $mapping->setType($elastica_type);
       $mapping->setParam('_all', array('enabled' => FALSE));
       try {
-        try {
-          // First we try a simple merge.
-          $mapping->setProperties($this->fieldsUpdatedProperties);
-          $mapping->send();
+        $fields = array();
+        foreach ($this->fieldsUpdatedProperties as $key => $value) {
+          if ($value['type']=='string') {
+            $value['type'] = 'keyword';
+          }
+          $fields[$key] = $value;
         }
-        catch (Exception $e) {
-          // If a merge fails, we must delete the type first.
-          $elastica_type->delete();
-          $elastica_type = $elastica_index->getType($index->machine_name);
-          $mapping->setType($elastica_type);
-          $mapping->send();
-        }
+        $mapping->setProperties($fields);
+        $mapping->send();
       }
       catch (Exception $e) {
         watchdog('Elasticsearch', check_plain($e->getMessage()), array(), WATCHDOG_ERROR);

--- a/modules/elastica/search_api_elasticsearch_elastica.drush.inc
+++ b/modules/elastica/search_api_elasticsearch_elastica.drush.inc
@@ -9,7 +9,7 @@
  *
  * @var string
  */
-const SEARCH_API_ELASTICSEARCH_ELASTICA_VERSION = '1.3.4.0';
+const SEARCH_API_ELASTICSEARCH_ELASTICA_VERSION = '5.1.0';
 
 /**
  * The URL of the Elastica Github Tarball.

--- a/modules/elastica/search_api_elasticsearch_elastica.module
+++ b/modules/elastica/search_api_elasticsearch_elastica.module
@@ -15,6 +15,7 @@ function search_api_elasticsearch_elastica_search_api_service_info() {
     <p>Index items using a !url_elasticsearch search server.</p>
     <ul>
     <li>All field types are supported.</li>
+    <li>Drupal <i>string</i> maps to Elasticsearch <i>keyword</> .</li>
     <li>Search API facets are supported.</li>
     <li>More Like This searches are supported.</li>
     <li>Will use internal elasticsearch preprocessors, so Search API preprocessors should for the most part be deactivated.</li>
@@ -141,6 +142,13 @@ function search_api_elasticsearch_elastica_form_alter(&$form, &$form_state, $for
       $add_options = search_api_elasticsearch_elastica_add_options($form_state['values']['server']);
       if ($add_options != FALSE) {
         search_api_elasticsearch_elastica_return_form_options($form, $form_state, $default_values, 'edit');
+      }
+    }
+  } elseif ($form_id == 'search_api_admin_index_fields') {
+    $fields = $form['fields'];
+    foreach ($fields as $key => $info) {
+      if ($form['fields'][$key]['type']['#type']== 'select') {
+        $form['fields'][$key]['type']['#options']['keyword'] = 'Keyword';
       }
     }
   }

--- a/templates/search-api-elasticsearch-index.tpl.php
+++ b/templates/search-api-elasticsearch-index.tpl.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * @file
+ */
+
+?>
+
+<h3><?php print $name; ?></h3>
+<dl>
+    <dt><?php print t('Status'); ?></dt>
+    <dd>
+      <?php print $enabled; ?>
+    </dd>
+
+    <dt><?php print t('Machine name'); ?></dt>
+    <dd>
+      <?php print $machine_name; ?>
+    </dd>
+
+    <dt><?php print t('Item type'); ?></dt>
+    <dd>
+      <?php print $item_type; ?>
+    </dd>
+
+    <?php if (!empty($description)) { ?>
+      <dt><?php print t('Description'); ?></dt>
+      <dd>
+        <?php print $description; ?>
+      </dd>
+    <?php } ?>
+
+    <?php if (!empty($server)) { ?>
+      <dt><?php print t('Server'); ?></dt>
+      <dd>
+        <?php print $server; ?>
+        <?php if (!empty($server_description)) { ?>
+          <p class="description">'<?php $server_description; ?></p>
+        <?php } ?>
+      </dd>
+    <?php } ?>
+
+    <?php if (isset($read_only) && $read_only == FALSE) { ?>
+      <dt><?php print t('Index options'); ?></dt>
+      <dd>
+        <dl>
+          <dt><?php print $cron_limit; ?></dt>
+
+          <?php if (isset($number_of_shards)) { ?>
+            <dt><?php print $number_of_shards; ?></dt>
+          <?php } ?>
+
+          <?php if (isset($number_of_replicas)) { ?>
+            <dt><?php print $number_of_replicas; ?></dt>
+          <?php } ?>
+        </dl>
+      </dd>
+    <?php } elseif (!empty($read_only)) { ?>
+      <dt><?php print t('Read only'); ?></dt>
+      <dd>
+        <?php print $read_only; ?>
+      </dd>
+    <?php } ?>
+
+    <dt><?php print t('Configuration status'); ?></dt>
+    <dd>
+      <?php print $configuration_status; ?>
+    </dd>
+</dl>


### PR DESCRIPTION
Updated the API to use Elastica 5 as the driver.
Updated the occurrences of the deprecated 'string' datatype to 'text' or 'keyword'.
Added 'date' extra formats to deal with Drupal using different date format when indexing.
Can no longer update mappings in ES5, removed that.
Added the ability to add mappings to an existing index.